### PR TITLE
chore(style): remove useless tabcard styling of `a` children

### DIFF
--- a/src/components/ui/tabcard.css
+++ b/src/components/ui/tabcard.css
@@ -57,14 +57,6 @@
   &:disabled {
     @apply pointer-events-none opacity-40;
   }
-
-  &:has(> a) {
-    @apply px-0;
-
-    a {
-      @apply flex h-full items-center justify-center px-6;
-    }
-  }
 }
 
 [data-slot='tabcard-content-wrapper'] {


### PR DESCRIPTION
Remove useless tabcard styling of `a` children since `asChild` attribute already does the job